### PR TITLE
Handle flow parse errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 const flowRemoveTypes = require('flow-remove-types')
-const requireIndex = require('requireindex')
 
 //------------------------------------------------------------------------------
 // Plugin Definition

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,8 +37,8 @@ module.exports = {
             severity: 2,
             source: null,
             message: `Flow parse failed: ${err.message}`,
-            line: err.loc.line,
-            column: err.loc.column
+            line: err.loc && err.loc.line,
+            column: err.loc && err.loc.column
           }];
         }
         return messages[0];

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const requireIndex = require('requireindex')
 module.exports = {
   processors: {
     '.js': {
-      preprocess: (text, filename) => [flowRemoveTypes(text)],
+      preprocess: (text, filename) => [flowRemoveTypes(text).toString()],
       postprocess: (messages, filename) => messages[0]
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,33 @@ const flowRemoveTypes = require('flow-remove-types')
 module.exports = {
   processors: {
     '.js': {
-      preprocess: (text, filename) => [flowRemoveTypes(text).toString()],
-      postprocess: (messages, filename) => messages[0]
+      _parseErrors: {},
+      preprocess: function(text, filename) {
+        let output;
+        try {
+          output = flowRemoveTypes(text);
+        } catch (err) {
+          this._parseErrors[filename] = err;
+          return [''];
+        }
+        this._parseErrors[filename] = null;
+        return [output.toString()];
+      },
+      postprocess: function(messages, filename) {
+        const err = this._parseErrors[filename];
+        if (err) {
+          return [{
+            ruleId: null,
+            fatal: true,
+            severity: 2,
+            source: null,
+            message: `Flow parse failed: ${err.message}`,
+            line: err.loc.line,
+            column: err.loc.column
+          }];
+        }
+        return messages[0];
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
-    "flow-remove-types": "^1.0.3",
-    "requireindex": "~1.1.0"
+    "flow-remove-types": "^1.0.3"
   },
   "devDependencies": {
     "eslint": "~2.6.0",


### PR DESCRIPTION
Each commit is an independent fix.
* Call toString() on the flowRemoveTypes results needed as it now returns an object with a toString() method.
* Removed unused requireindex dependency.
* Handled flow parse errors, returning an eslint message from postprocess. I don't think it's possible to return a message from preprocess.

The last commit makes VSCode eslint integration much more pleasant as the thrown exception ends up in a semi-modal dialog.